### PR TITLE
Add support for OSPF auto-cost reference-bandwidth

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,6 +14,7 @@ quagga::bgpd: false
 
 quagga::ospfd: false
 quagga::ospf_area: '0.0.0.0'
+quagga::ospf_ref_bw: '100'
 
 quagga::ospf6d: false
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class quagga (
     $ospfd               = undef,
     $ospf_area           = undef,
     $ospf6d              = undef,
+    $ospf_ref_bw         = undef,
     $ripd                = undef,
     $ripngd              = undef,
     $isisd               = undef,

--- a/templates/ospfd.erb
+++ b/templates/ospfd.erb
@@ -8,6 +8,7 @@ interface <%= name %>
 !
 router ospf
   ospf router-id <%= @router_id %>
+  auto-cost reference-bandwidth <%= @ospf_ref_bw %>
 <%- @ospf_areas.each do |area, opt| -%>
   area <%= area %><%= opt['range'] && " range #{opt['range']}" %>
 <%- end -%>


### PR DESCRIPTION
Under "router ospf" there is the option "auto-cost reference-bandwidth"
which allows one to set base reference bandwidth in order to handle
high bandwidth (10GE+) links.

From http://www.nongnu.org/quagga/docs/docs-multi/OSPF-router.html:

"This sets the reference bandwidth for cost calculations, where this
bandwidth is considered equivalent to an OSPF cost of 1, specified in
Mbits/s. The default is 100Mbit/s (i.e. a link of bandwidth 100Mbit/s or
higher will have a cost of 1. Cost of lower bandwidth links will be
scaled with reference to this cost).

This configuration setting MUST be consistent across all routers within
the OSPF domain."